### PR TITLE
directories that start with . were getting added to the database.

### DIFF
--- a/src/com/pugh/sockso/music/indexing/TrackFileFilter.java
+++ b/src/com/pugh/sockso/music/indexing/TrackFileFilter.java
@@ -21,9 +21,9 @@ public class TrackFileFilter implements FileFilter {
 
         final String ext = Utils.getExt( file.getName() ).toLowerCase();
 
-        return file.isDirectory() ||                                                // is a directory
+        return (file.isDirectory() ||                                                // is a directory
             ( ext.equals("mp3") || ext.equals("wma") || ext.equals("ogg")           // OR is an audio file
-              || ext.equals("asf") || ext.equals("flac") || ext.equals("m4a") )
+              || ext.equals("asf") || ext.equals("flac") || ext.equals("m4a") ))
             && !file.getName().substring( 0, 1 ).equals( "." );                     // AND not hidden file
         
     }


### PR DESCRIPTION
Fixed the problem with directories that start with dot getting added to the database.
The problem was observed on OS X where the system creates .AppleDouble folders.
