### PR TITLE
fix for issue 28

### DIFF
--- a/src/com/pugh/sockso/music/Album.java
+++ b/src/com/pugh/sockso/music/Album.java
@@ -37,7 +37,7 @@ public class Album extends MusicItem {
         this.trackCount = trackCount;
         this.playCount = playCount;
         this.dateAdded = ( dateAdded != null ) ? new Date(dateAdded.getTime()) : null;
-        this.year = year;
+        this.year = ( year != null ) ? year : "";
     }
     
     public Artist getArtist() { return artist; }


### PR DESCRIPTION
if there's no year field in the database, it crashes the latest version.
