### PR TITLE
HTML 5 Player fixes

### DIFF
--- a/resources/htdocs/js/sockso.Html5Player.js
+++ b/resources/htdocs/js/sockso.Html5Player.js
@@ -11,6 +11,7 @@ sockso.Html5Player = function() {
 
     var self = this,
         playlist = [],
+        reloadWhenFinished = false,
         playing = null,
         artworkDiv = null,
         controlsDiv = null,
@@ -129,6 +130,10 @@ sockso.Html5Player = function() {
 
         if ( playing != -1 && playing < playlist.length - 1 ) {
             self.playItem( playing + 1 );
+        } else if (reloadWhenFinished && playing >= playlist.length - 1) {
+        	// We're in random mode, refresh the page
+        	// in order to get more random tracks
+        	window.location.reload();
         }
 
     };
@@ -167,7 +172,7 @@ sockso.Html5Player = function() {
      *  
      */
 
-    this.init = function( playerDivId, skin ) {
+    this.init = function( playerDivId, skin, random ) {
 
         /**
          *  Creates and returns a control for the controls panel
@@ -194,12 +199,14 @@ sockso.Html5Player = function() {
         }
        
         skin = skin || 'original';
+        reloadWhenFinished = random || false;
 
         audioElt = $('<audio></audio>')
         			.attr( 'controls', 'controls')
         			.attr( 'autoplay', 'autoplay')
 					.text( 'Your browser doesn\'t support HTML 5 <audio> element.' )
-					.error ( function () { html5player.playNextItem(); } );
+					.error ( function () { html5player.playNextItem(); } )
+        			.bind ( 'ended', function () { html5player.playNextItem(); } );
         
         var audioDiv = $( '<div></div>' )
         			.addClass( 'audio' )

--- a/src/com/pugh/sockso/web/action/Player.java
+++ b/src/com/pugh/sockso/web/action/Player.java
@@ -56,7 +56,8 @@ public class Player extends WebAction {
         	showHtml5Player(
         		req.getUrlParam( 2 ).equals( "random" )
         			? getRandomTracks()
-        			: getRequestedTracks( playArgs )
+        			: getRequestedTracks( playArgs ),
+        		req.getUrlParam( 2 ).equals( "random" )
         	);
         }
         
@@ -105,17 +106,19 @@ public class Player extends WebAction {
      *  shows the HTML 5 player
      * 
      *  @param tracks
+     *  @param random
      * 
      *  @throws IOException
      * 
      */
     
-    protected void showHtml5Player( final Vector<Track> tracks ) throws IOException {
+    protected void showHtml5Player( final Vector<Track> tracks, boolean random ) throws IOException {
 
         final THtml5Player tpl = new THtml5Player();
         
         tpl.setTracks( tracks );
         tpl.setProperties( getProperties() );
+        tpl.setRandom( random );
         
         getResponse().showHtml( tpl.makeRenderer() );
 

--- a/templates/com/pugh/sockso/templates/web/THtml5Player.jamon
+++ b/templates/com/pugh/sockso/templates/web/THtml5Player.jamon
@@ -10,6 +10,7 @@
 <%args>
     Properties properties = null;
     Vector<Track> tracks = null;
+    boolean random = false;
 </%args>
 
 <%java>
@@ -41,7 +42,7 @@ var html5player;
 $(document).ready( function() {
 
 	html5player = new sockso.Html5Player();
-	html5player.init( 'html5player', '<% skin %>' );
+	html5player.init( 'html5player', '<% skin %>', <% Boolean.toString(random) %> );
 
     <%for final Track track : tracks %>
         html5player.addTrack({

--- a/test/com/pugh/sockso/web/action/PlayerTest.java
+++ b/test/com/pugh/sockso/web/action/PlayerTest.java
@@ -110,7 +110,7 @@ public class PlayerTest extends SocksoTestCase {
         
         player.setProperties( new StringProperties() );
         player.setResponse( res );
-        player.showHtml5Player( tracks );
+        player.showHtml5Player( tracks, false );
         
         final String data = res.getOutput();
         


### PR DESCRIPTION
Hi,

Here are a couple of fixes for the HTML 5 player:
- Play next item when an item finished: That was definitely working as I listened several hours of music using the HTML 5 player yesterday, but I don't know how since there was no code to capture the "media ended" event and skip to the next !
- In random mode, refresh the page at the end of the playlist to get a fresh random playlist.

Let me know if this is suitable for merging or if you need modifications.

Cheers,

Nico
