### PR TITLE
Some HTML 5 player refinements

### DIFF
--- a/test/js/jsTestDriver.conf
+++ b/test/js/jsTestDriver.conf
@@ -32,7 +32,6 @@ load:
     - sockso.LocaleTest.js
     - sockso.SearchBoxTest.js
     - sockso.PlayerTest.js
-    - sockso.JSPlayerTest.js
     - sockso.Html5PlayerTest.js
     - sockso.UploadFormTest.js
     - sockso.PlaylistTest.js

--- a/test/js/sockso.Html5PlayerTest.js
+++ b/test/js/sockso.Html5PlayerTest.js
@@ -1,7 +1,7 @@
 
-JSPlayer = TestCase( 'sockso.Html5Player' );
+Html5Player = TestCase( 'sockso.Html5Player' );
 
-JSPlayer.prototype.getHtml5Player = function() {
+Html5Player.prototype.getHtml5Player = function() {
 
     var playerId = 'socksoHtml5Player';
 
@@ -17,7 +17,7 @@ JSPlayer.prototype.getHtml5Player = function() {
 
 };
 
-JSPlayer.prototype.testInit = function() {
+Html5Player.prototype.testInit = function() {
 
     var player = this.getHtml5Player();
 
@@ -32,7 +32,7 @@ JSPlayer.prototype.testInit = function() {
 
 };
 
-JSPlayer.prototype.getTrack = function(id) {
+Html5Player.prototype.getTrack = function(id) {
 	
 	var id = id || '123';
 
@@ -51,7 +51,81 @@ JSPlayer.prototype.getTrack = function(id) {
 
 }
 
-JSPlayer.prototype.testPlayPrevNext = function() {
+
+Html5Player.prototype.testKeyHandlerVolume = function() {
+    
+    var player = this.getHtml5Player();
+    
+    assertEquals(player.volumeIndex, HTML5PLAYER_VOLUME_STEPS.length-1);
+
+    player.keyHandler({
+        keyCode: 's'.charCodeAt(0),
+        data: { player: player }
+     });
+    player.keyHandler({
+        keyCode: 's'.charCodeAt(0),
+        data: { player: player }
+     });
+    player.keyHandler({
+        keyCode: 'S'.charCodeAt(0),
+        data: { player: player }
+     });
+    
+    assertEquals(player.volumeIndex, HTML5PLAYER_VOLUME_STEPS.length-4);
+    
+    player.keyHandler({
+        keyCode: 'W'.charCodeAt(0),
+        data: { player: player }
+     });
+    player.keyHandler({
+        keyCode: 'w'.charCodeAt(0),
+        data: { player: player }
+     });
+    
+    assertEquals(player.volumeIndex, HTML5PLAYER_VOLUME_STEPS.length-2);
+
+}
+
+Html5Player.prototype.testKeyHandlerPrevNext = function() {
+    
+    var player = this.getHtml5Player();
+    
+    player.addTrack( this.getTrack('123') );
+    player.addTrack( this.getTrack('456') );
+    player.addTrack( this.getTrack('789') );
+    
+    player.start();
+    
+    assertEquals( 1, $('#item123.current').length);
+    
+    player.keyHandler({
+       keyCode: 'd'.charCodeAt(0),
+       data: { player: player }
+    });
+    
+    assertEquals( 1, $('#item456.current').length);
+    
+    player.keyHandler({
+        keyCode: 'a'.charCodeAt(0),
+        data: { player: player }
+     });
+    
+    assertEquals( 1, $('#item123.current').length);
+    
+    player.keyHandler({
+        keyCode: 'D'.charCodeAt(0),
+        data: { player: player }
+     });
+    player.keyHandler({
+        keyCode: 'D'.charCodeAt(0),
+        data: { player: player }
+     });
+    
+    assertEquals( 1, $('#item789.current').length);
+
+}
+
+Html5Player.prototype.testPlayPrevNext = function() {
 
     var player = this.getHtml5Player();
     var track = this.getTrack();
@@ -112,7 +186,7 @@ JSPlayer.prototype.testPlayPrevNext = function() {
 
 };
 
-JSPlayer.prototype.testStopPlaying = function() {
+Html5Player.prototype.testStopPlaying = function() {
 
     var player = this.getHtml5Player();
     var track = this.getTrack();
@@ -126,7 +200,7 @@ JSPlayer.prototype.testStopPlaying = function() {
 
 };
 
-JSPlayer.prototype.testPlayItem = function() {
+Html5Player.prototype.testPlayItem = function() {
 
     var player = this.getHtml5Player();
     var track = this.getTrack();


### PR DESCRIPTION
Hi, here are some improvements of the HTML 5 player:

**Set window title to current track being played**, including the current track number over the total of the current playlist

**Ensure playlist is always displaying the current item**

Previously the current item was given a specific CSS class, but once it has "escaped" the current visible/scrollable window it was hidden unless you scrolled the playlist.
Now the current track is always the first in the playlist. I used a navigation to the current item anchor, which is not ideal, but I couldn't find a reliable way with `jQuery.scrollTop()` and co...

**Key shortcuts for prev/next, and vol up/down**
- `A/D` : previous / next
- `S/W` : Volume up / down
- `Space`: pause/play

These bindings are not ideal, but it seems that using letters is the only way to be reliably cross-browser. I tried with `+/-` for the volume but FF and Chrome gave different key codes...

For the volume I had to use fixed steps (`0, .1, .2, .3 ... 1`) because the volume value on the %lt;audio&gt; element a float (`0.0 .. 1.0`), and just adding .1 or removing it fails because of floating point precision (`.5 - .1 = .399999` ...)

Finally I tried to use 4 white spaces instead of tab ;)

Cheers,

Nico
