### PR TITLE
Try to recover from OutOfMemory during indexing

### DIFF
--- a/src/com/pugh/sockso/music/DBCollectionManager.java
+++ b/src/com/pugh/sockso/music/DBCollectionManager.java
@@ -91,8 +91,8 @@ public class DBCollectionManager extends Thread implements CollectionManager, In
 
         }
 
-        catch ( final Exception e ) {
-            log.debug( e );
+        catch ( final Throwable t ) {
+            log.debug( "indexChanged error on file '" + evt.getFile().getAbsolutePath() + "'", t );
         }
 
     }


### PR DESCRIPTION
Hi,

On my library I got the following exception when indexing it:

<pre>
Exception in thread "Thread-4" java.lang.OutOfMemoryError: Java heap space
        at org.kc7bfi.jflac.metadata.Picture.<init>(Picture.java:64)
        at org.kc7bfi.jflac.FLACDecoder.readNextMetadata(FLACDecoder.java:607)
        at org.kc7bfi.jflac.FLACDecoder.readMetadata(FLACDecoder.java:249)
        at com.pugh.sockso.music.tag.FlacTag.parse(Unknown Source)
        at com.pugh.sockso.music.tag.AudioTag.getTag(Unknown Source)
        at com.pugh.sockso.music.DBCollectionManager.addFile(Unknown Source)
        at com.pugh.sockso.music.DBCollectionManager.indexChanged(Unknown Source)
        at com.pugh.sockso.music.indexing.BaseIndexer.fireIndexEvent(Unknown Source)
        at com.pugh.sockso.music.indexing.BaseIndexer.scan(Unknown Source)
        at com.pugh.sockso.music.indexing.BaseIndexer.scan(Unknown Source)
        at com.pugh.sockso.music.indexing.BaseIndexer.scan(Unknown Source)
        at com.pugh.sockso.music.indexing.BaseIndexer.scan(Unknown Source)
        at com.pugh.sockso.music.indexing.BaseIndexer.checkForNewFiles(Unknown Source)  
        at com.pugh.sockso.music.indexing.BaseIndexer.scan(Unknown Source)
        at com.pugh.sockso.music.scheduling.SchedulerRunner.run(Unknown Source)
</pre>


I suspect this is due to the underlying tagging library (In this case FLAC) failing to read the comment blocks that contains a hi-res cover picture. Raising the heap size on java startup didn't help.

While I'll try to have a look into fixing that in jFlac, an easy workaround in Sockso could be to catch Throwable instead of Exception in `DBCollectionManager`. That way at least the indexing will skip the file and continue on the next one instead of failing the whole task.

Cheers,

Nico
